### PR TITLE
fix wrong method reference

### DIFF
--- a/src/scormify.js
+++ b/src/scormify.js
@@ -25,7 +25,7 @@ var SCORMify = (function () {
         var scormApi = findLMS(window);
 
         if ((scormApi == null) && (window.opener != null) && (typeof (window.opener) != "undefined"))
-            scormApi = findAPI(window.opener);
+            scormApi = findLMS(window.opener);
 
         if (scormApi == null)
             alert("Unable to find an API adapter");


### PR DESCRIPTION
In case the SCORM "app" is launched in a popup, the method called to retrieve LMS api was not the proper one.